### PR TITLE
Added button to assignment and exam but not challenge

### DIFF
--- a/src/app/course/course-question-snippet/course-question-snippet.component.html
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.html
@@ -1,4 +1,15 @@
 <ng-container *ngIf="uqjs">
+    <button
+        *ngIf="event.type==='ASSIGNMENT'||event.type==='EXAM'"
+        appearance="flat"
+        [routerLink]="['..']"
+        icon="tuiIconArrowLeft"
+        aria-label="Back to Homepage"
+        size="s"
+        tuiButton
+    >
+        Homepage
+    </button>
     <div [class.tui-container]="eventId" [class.tui-container_adaptive]="eventId">
         <div *ngIf="eventId" class="flex justify-between items-center">
             <h1 class="tui-text_h3 tui-space_vertical-10">{{ event.name }}</h1>

--- a/src/app/course/course-question-snippet/course-question-snippet.component.html
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.html
@@ -4,11 +4,11 @@
         appearance="flat"
         [routerLink]="['..']"
         icon="tuiIconArrowLeft"
-        aria-label="Back to Homepage"
+        aria-label="Back to Assignments/Exams"
         size="s"
         tuiButton
     >
-        Homepage
+        Assignments/Exams
     </button>
     <div [class.tui-container]="eventId" [class.tui-container_adaptive]="eventId">
         <div *ngIf="eventId" class="flex justify-between items-center">

--- a/src/app/course/course-question-snippet/course-question-snippet.component.html
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.html
@@ -4,11 +4,11 @@
         appearance="flat"
         [routerLink]="['..']"
         icon="tuiIconArrowLeft"
-        aria-label="Back to Assignments/Exams"
+        aria-label="Back to Assignments and Exams"
         size="s"
         tuiButton
     >
-        Assignments/Exams
+        Assignments and Exams
     </button>
     <div [class.tui-container]="eventId" [class.tui-container_adaptive]="eventId">
         <div *ngIf="eventId" class="flex justify-between items-center">

--- a/src/app/course/course-question-snippet/course-question-snippet.component.html
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.html
@@ -1,16 +1,16 @@
 <ng-container *ngIf="uqjs">
-    <button
-        *ngIf="event.type==='ASSIGNMENT'||event.type==='EXAM'"
-        appearance="flat"
-        [routerLink]="['..']"
-        icon="tuiIconArrowLeft"
-        aria-label="Back to Assignments and Exams"
-        size="s"
-        tuiButton
-    >
-        Assignments and Exams
-    </button>
     <div [class.tui-container]="eventId" [class.tui-container_adaptive]="eventId">
+        <button
+            *ngIf="event.type === 'ASSIGNMENT' || event.type === 'EXAM'"
+            appearance="flat"
+            [routerLink]="['..']"
+            icon="tuiIconArrowLeft"
+            aria-label="Back to Assignments and Exams"
+            size="s"
+            tuiButton
+        >
+            Back to Assignments and Exams
+        </button>
         <div *ngIf="eventId" class="flex justify-between items-center">
             <h1 class="tui-text_h3 tui-space_vertical-10">{{ event.name }}</h1>
             <div>


### PR DESCRIPTION
## Description

Describe your changes in detail

Added a button to the question snippet template with an ngIf that checks if the event type is an assignment or exam and if so displays a button to return to the assignments and exams tab.

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

Please link the issue here.

https://github.com/COSC447-Directed-Studies/canvas-gamification-ui/issues/14

## Tests

Please describe in detail what tests you added or changed.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/79422004/214397709-6b5ef80a-27ea-4f2c-b18f-491f01095faa.png)
![image](https://user-images.githubusercontent.com/79422004/214397764-b7f287b2-cbf9-463a-a62b-636cf01f2429.png)

