### PR TITLE
add-routing-to-concept-map-from-assignment

### DIFF
--- a/src/app/course/course-question-snippet/course-question-snippet.component.html
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.html
@@ -183,7 +183,7 @@
                     </h2>
                     <h2 class="mt-3">
                         To add questions go to the
-                        <a [routerLink]="['../../practice/concepts']" class="colorpls">
+                        <a [routerLink]="['../../practice/concepts']" class="color-link">
                             Concept Map
                         </a>
                     </h2>
@@ -195,7 +195,7 @@
                         </h2>
                         <h2 class="mt-3">
                             To add questions go to the
-                            <a [routerLink]="['../../practice/concepts']" class="colorpls">
+                            <a [routerLink]="['../../practice/concepts']" class="color-link">
                                 Concept Map
                             </a>
                         </h2>

--- a/src/app/course/course-question-snippet/course-question-snippet.component.html
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.html
@@ -73,6 +73,14 @@
         >
             The {{getEventType()}} is closed.
         </tui-notification>
+        <tui-notification
+            class="mb-6"
+        >
+            To add questions go to the
+            <a [routerLink]="['../../practice/concepts']" class="colorpls">
+                Concept Map
+            </a>
+        </tui-notification>
         <ng-container *ngIf="event.is_open || course.has_create_event_permission">
             <div
                 *ngIf="event.type==='CHALLENGE' && team"

--- a/src/app/course/course-question-snippet/course-question-snippet.component.html
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.html
@@ -6,9 +6,22 @@
             size="s"
             tuiButton
             appearance="flat"
+            class="mb-6"
         >
             Back to {{getBackLabel()}}
         </a>
+        <tui-notification
+            class="mb-6"
+            *ngIf="event.is_not_available_yet"
+        >
+            The {{getEventType()}} is not available yet.
+        </tui-notification>
+        <tui-notification
+            class="mb-6"
+            *ngIf="event.is_closed"
+        >
+            The {{getEventType()}} is closed.
+        </tui-notification>
         <div *ngIf="eventId" class="flex justify-between items-center mt-3 mb-10">
             <h5 class="tui-text_h5">{{ event.name }}</h5>
             <div class="flex flex-row gap-3" *ngIf="event.has_edit_permission">
@@ -61,26 +74,16 @@
                 </ng-template>
             </div>
         </div>
-        <tui-notification
-            class="mb-6"
-            *ngIf="event.is_not_available_yet"
+        <div
+            class="mb-6 -mt-5"
+            *ngIf="uqjs.length"
         >
-            The {{getEventType()}} is not available yet.
-        </tui-notification>
-        <tui-notification
-            class="mb-6"
-            *ngIf="event.is_closed"
-        >
-            The {{getEventType()}} is closed.
-        </tui-notification>
-        <tui-notification
-            class="mb-6"
-        >
-            To add questions go to the
-            <a [routerLink]="['../../practice/concepts']" class="colorpls">
-                Concept Map
-            </a>
-        </tui-notification>
+            <p class="tui-island__paragraph tui-text_body-xl">To add questions go to the
+                <a [routerLink]="['../../practice/concepts']" class="color-link">
+                    Concept Map
+                </a>
+            </p>
+        </div>
         <ng-container *ngIf="event.is_open || course.has_create_event_permission">
             <div
                 *ngIf="event.type==='CHALLENGE' && team"
@@ -173,16 +176,31 @@
                 </tui-island>
             </div>
             <ng-container *ngIf="!uqjs.length">
-                <h2
-                    *ngIf="eventId; else inCourse"
-                    class="tui-text_h6 tui-space_auto no-content-heading"
-                >
-                    There aren't any questions available in this {{getEventType()}}.
-                </h2>
-                <ng-template #inCourse>
-                    <h2 class="tui-text_h6 tui-space_auto no-content-heading">
-                        There aren't any questions available in this course.
+                <div *ngIf="eventId; else inCourse"
+                     class="tui-text_h6 tui-space_auto no-content-heading">
+                    <h2>
+                        There aren't any questions available in this {{getEventType()}}.
                     </h2>
+                    <h2 class="mt-3">
+                        To add questions go to the
+                        <a [routerLink]="['../../practice/concepts']" class="colorpls">
+                            Concept Map
+                        </a>
+                    </h2>
+                </div>
+                <ng-template #inCourse>
+                    <div class="tui-text_h6 tui-space_auto no-content-heading">
+                        <h2>
+                            There aren't any questions available in this course.
+                        </h2>
+                        <h2 class="mt-3">
+                            To add questions go to the
+                            <a [routerLink]="['../../practice/concepts']" class="colorpls">
+                                Concept Map
+                            </a>
+                        </h2>
+                    </div>
+
                 </ng-template>
             </ng-container>
         </ng-container>

--- a/src/app/course/course-question-snippet/course-question-snippet.component.scss
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.scss
@@ -22,6 +22,6 @@
     }
 }
 
-.colorpls {
+.color-link {
     color: var(--tui-support-02);
 }

--- a/src/app/course/course-question-snippet/course-question-snippet.component.scss
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.scss
@@ -21,3 +21,7 @@
         transform: rotate(180deg);
     }
 }
+
+.colorpls {
+    color: var(--tui-support-02);
+}


### PR DESCRIPTION
## Description

Describe your changes in detail

Moved error messages such as the 'this event-type is closed' above the event name. If there are no questions in the event, displays a bolded instruction and link to concept map to add questions underneath the message informing the user of the lack of questions. If there are questions, added same message in the instruction text font used in the first layer of the question bank tab. Added css to change the colour of the word "concept map" to highlight that it is a link.

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

Please link the issue here.
https://github.com/COSC447-Directed-Studies/canvas-gamification-ui/issues/44

## Tests

Please describe in detail what tests you added or changed.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/79422004/217948774-cac291f8-e39d-437d-948a-07b828b0fe9b.png)
![image](https://user-images.githubusercontent.com/79422004/218385909-3365ab76-227f-4a12-8474-a716ab5b956a.png)
