### PR TITLE
Popup for editing assignments and their questions after closed

### DIFF
--- a/src/app/course/course-question-snippet/course-question-snippet.component.html
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.html
@@ -168,18 +168,8 @@
                             </a>
                         </ng-template>
                         <a
-                            *ngIf="event.has_edit_permission && (event.is_closed && !event.is_not_available_yet)"
-                            (click)="openEditQuestionInClosedEventDialog(editQuestion)"
-                            appearance="primary"
-                            class="tui-form__button"
-                            size="s"
-                            tuiButton
-                        >
-                            Edit
-                        </a>
-                        <a
-                            *ngIf="event.has_edit_permission && (event.is_open || event.is_not_available_yet)"
-                            [routerLink]="['problem', uqj.question.id, 'edit']"
+                            *ngIf="event.has_edit_permission"
+                            (click)="openEditQuestionInEventDialog(editQuestion, event.is_closed && !event.is_not_available_yet, uqj)"
                             appearance="primary"
                             class="tui-form__button"
                             size="s"

--- a/src/app/course/course-question-snippet/course-question-snippet.component.html
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.html
@@ -168,7 +168,17 @@
                             </a>
                         </ng-template>
                         <a
-                            *ngIf="event.has_edit_permission"
+                            *ngIf="event.has_edit_permission && (event.is_closed && !event.is_not_available_yet)"
+                            (click)="openEditQuestionInClosedEventDialog(editQuestion)"
+                            appearance="primary"
+                            class="tui-form__button"
+                            size="s"
+                            tuiButton
+                        >
+                            Edit
+                        </a>
+                        <a
+                            *ngIf="event.has_edit_permission && (event.is_open || event.is_not_available_yet)"
                             [routerLink]="['problem', uqj.question.id, 'edit']"
                             appearance="primary"
                             class="tui-form__button"
@@ -177,6 +187,29 @@
                         >
                             Edit
                         </a>
+                        <ng-template #editQuestion let-observer>
+                            <p>This event has finished. Are you sure that you would like to edit this question?</p>
+                            <div class="tui-form__buttons">
+                                <button
+                                    (click)="observer.complete()"
+                                    [routerLink]="['problem', uqj.question.id, 'edit']"
+                                    class="tui-form__button"
+                                    size="m"
+                                    tuiButton
+                                >
+                                    Edit Question
+                                </button>
+                                <button
+                                    (click)="observer.complete()"
+                                    appearance="secondary"
+                                    class="tui-form__button"
+                                    size="m"
+                                    tuiButton
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        </ng-template>
                         <a
                             *ngIf="event.has_edit_permission"
                             (click)="removeQuestion(uqj.question.id)"

--- a/src/app/course/course-question-snippet/course-question-snippet.component.ts
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.ts
@@ -151,6 +151,8 @@ export class CourseQuestionSnippetComponent implements OnInit {
     /**
      * Opens the dialog service based on the template passed
      * @param content - the template to be used
+     * @param openDialog - the boolean condition used to check if template should be opened
+     * @param uqj - the question to be edited
      */
     openEditQuestionInEventDialog(
         content: PolymorpheusContent<TuiDialogContext>,

--- a/src/app/course/course-question-snippet/course-question-snippet.component.ts
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core'
+import {Component, Inject, OnInit} from '@angular/core'
 import {Course, CourseEvent, UQJ, User} from '@app/_models'
 import {AuthenticationService} from '@app/_services/api/authentication'
 import {ActivatedRoute, Router} from '@angular/router'
@@ -9,8 +9,14 @@ import {CourseService} from '@app/course/_services/course.service'
 import {TuiStatusT} from "@taiga-ui/kit"
 import {Team} from "@app/_models/team"
 import {TeamService} from "@app/course/_services/team.service"
-import {TuiNotification, TuiNotificationsService} from "@taiga-ui/core"
+import {
+    TuiDialogContext,
+    TuiNotification,
+    TuiNotificationsService,
+    TuiDialogService
+} from "@taiga-ui/core"
 import {startCase} from "lodash"
+import {PolymorpheusContent} from "@tinkoff/ng-polymorpheus"
 
 @Component({
     selector: 'app-course-question-snippet',
@@ -36,6 +42,7 @@ export class CourseQuestionSnippetComponent implements OnInit {
         private courseService: CourseService,
         private teamService: TeamService,
         private readonly notificationService: TuiNotificationsService,
+        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
     ) {
         this.authenticationService.currentUser.subscribe(user => this.user = user)
     }
@@ -139,5 +146,19 @@ export class CourseQuestionSnippetComponent implements OnInit {
             case 'TOP_TEAMS':
                 return `Teams earn tokens by staying on the top ${this.event.challenge_type_value} teams of this challenge. Each member gets the number of tokens equivalent to team tokens as the challenge ends.`
         }
+    }
+
+    /**
+     * Opens the dialog service based on the template passed
+     * @param content - the template to be used
+     */
+    openEditQuestionInClosedEventDialog(
+        content: PolymorpheusContent<TuiDialogContext>
+    ): void {
+
+        this.dialogService.open(content, {
+            closeable: false,
+            label: 'Edit Question in Finished Event?'
+        }).subscribe()
     }
 }

--- a/src/app/course/course-question-snippet/course-question-snippet.component.ts
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.ts
@@ -152,13 +152,18 @@ export class CourseQuestionSnippetComponent implements OnInit {
      * Opens the dialog service based on the template passed
      * @param content - the template to be used
      */
-    openEditQuestionInClosedEventDialog(
-        content: PolymorpheusContent<TuiDialogContext>
+    openEditQuestionInEventDialog(
+        content: PolymorpheusContent<TuiDialogContext>,
+        openDialog: boolean,
+        uqj: UQJ
     ): void {
-
-        this.dialogService.open(content, {
-            closeable: false,
-            label: 'Edit Question in Finished Event?'
-        }).subscribe()
+        if(openDialog) {
+            this.dialogService.open(content, {
+                closeable: false,
+                label: 'Edit Question in Finished Event?'
+            }).subscribe()
+        } else{
+            this.router.navigate(['/course', this.event.course, 'assignments-exams', this.eventId, 'problem', uqj.question.id, 'edit']).then()
+        }
     }
 }

--- a/src/app/course/event/event-row/event-row.component.html
+++ b/src/app/course/event/event-row/event-row.component.html
@@ -80,7 +80,19 @@
         <ng-template #viewTooltip>
             View
         </ng-template>
-        <button *ngIf="event.has_edit_permission"
+        <button *ngIf="event.has_edit_permission && (event.is_closed && !event.is_not_available_yet)"
+                (click)="openEditClosedEventDialog(editEvent)"
+                [tuiHint]="editTooltip"
+                class="tui-space_right-2 tui-space_vertical-2"
+                icon="tuiIconEdit"
+                size="s"
+                tuiDescribedBy="edit"
+                tuiHintDirection="top-left"
+                tuiHintId="edit"
+                tuiHintMode="onDark"
+                tuiIconButton
+        ></button>
+        <button *ngIf="event.has_edit_permission && (event.is_open || event.is_not_available_yet)"
                 [routerLink]="['/course', event.course, 'assignments-exams', event.id, 'edit']"
                 [tuiHint]="editTooltip"
                 class="tui-space_right-2 tui-space_vertical-2"
@@ -94,6 +106,29 @@
         ></button>
         <ng-template #editTooltip>
             Edit
+        </ng-template>
+        <ng-template #editEvent let-observer>
+            <p>This event has finished. Are you sure that you would like to edit this event?</p>
+            <div class="tui-form__buttons">
+                <button
+                    (click)="observer.complete()"
+                    [routerLink]="['/course', event.course, 'assignments-exams', event.id, 'edit']"
+                    class="tui-form__button"
+                    size="m"
+                    tuiButton
+                >
+                    Edit Event
+                </button>
+                <button
+                    (click)="observer.complete()"
+                    appearance="secondary"
+                    class="tui-form__button"
+                    size="m"
+                    tuiButton
+                >
+                    Cancel
+                </button>
+            </div>
         </ng-template>
         <button *ngIf="event.has_edit_permission"
                 [routerLink]="['/course', event.course, 'assignments-exams', event.id, 'stats']"

--- a/src/app/course/event/event-row/event-row.component.html
+++ b/src/app/course/event/event-row/event-row.component.html
@@ -80,20 +80,8 @@
         <ng-template #viewTooltip>
             View
         </ng-template>
-        <button *ngIf="event.has_edit_permission && (event.is_closed && !event.is_not_available_yet)"
-                (click)="openEditClosedEventDialog(editEvent)"
-                [tuiHint]="editTooltip"
-                class="tui-space_right-2 tui-space_vertical-2"
-                icon="tuiIconEdit"
-                size="s"
-                tuiDescribedBy="edit"
-                tuiHintDirection="top-left"
-                tuiHintId="edit"
-                tuiHintMode="onDark"
-                tuiIconButton
-        ></button>
-        <button *ngIf="event.has_edit_permission && (event.is_open || event.is_not_available_yet)"
-                [routerLink]="['/course', event.course, 'assignments-exams', event.id, 'edit']"
+        <button *ngIf="event.has_edit_permission"
+                (click)="openEditDialog(editEvent, event.is_closed && !event.is_not_available_yet)"
                 [tuiHint]="editTooltip"
                 class="tui-space_right-2 tui-space_vertical-2"
                 icon="tuiIconEdit"

--- a/src/app/course/event/event-row/event-row.component.ts
+++ b/src/app/course/event/event-row/event-row.component.ts
@@ -1,8 +1,14 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core'
+import {Component, EventEmitter, Inject, Input, OnInit, Output} from '@angular/core'
 import {CourseEvent, User} from "@app/_models"
 import {AuthenticationService} from "@app/_services/api/authentication"
-import {TuiNotification, TuiNotificationsService} from "@taiga-ui/core"
+import {
+    TuiNotification,
+    TuiNotificationsService,
+    TuiDialogContext,
+    TuiDialogService
+} from "@taiga-ui/core"
 import {CourseEventService} from "@app/course/_services/course-event.service"
+import {PolymorpheusContent} from "@tinkoff/ng-polymorpheus"
 
 @Component({
     selector: 'app-event-row',
@@ -18,8 +24,10 @@ export class EventRowComponent implements OnInit {
     constructor(
         private readonly authenticationService: AuthenticationService,
         private readonly courseEventService: CourseEventService,
-        private readonly notificationsService: TuiNotificationsService
-    ) { }
+        private readonly notificationsService: TuiNotificationsService,
+        @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
+    ) {
+    }
 
     ngOnInit(): void {
         this.authenticationService.currentUser.subscribe(user => this.user = user)
@@ -32,5 +40,19 @@ export class EventRowComponent implements OnInit {
             }).subscribe()
             this.reload.emit(true)
         })
+    }
+
+    /**
+     * Opens the dialog service based on the template passed
+     * @param content - the template to be used
+     */
+    openEditClosedEventDialog(
+        content: PolymorpheusContent<TuiDialogContext>
+    ): void {
+
+        this.dialogService.open(content, {
+            closeable: false,
+            label: 'Edit Finished Event?'
+        }).subscribe()
     }
 }

--- a/src/app/course/event/event-row/event-row.component.ts
+++ b/src/app/course/event/event-row/event-row.component.ts
@@ -8,6 +8,7 @@ import {
     TuiDialogService
 } from "@taiga-ui/core"
 import {CourseEventService} from "@app/course/_services/course-event.service"
+import {Router} from "@angular/router"
 import {PolymorpheusContent} from "@tinkoff/ng-polymorpheus"
 
 @Component({
@@ -25,6 +26,7 @@ export class EventRowComponent implements OnInit {
         private readonly authenticationService: AuthenticationService,
         private readonly courseEventService: CourseEventService,
         private readonly notificationsService: TuiNotificationsService,
+        private router: Router,
         @Inject(TuiDialogService) private readonly dialogService: TuiDialogService,
     ) {
     }
@@ -45,14 +47,19 @@ export class EventRowComponent implements OnInit {
     /**
      * Opens the dialog service based on the template passed
      * @param content - the template to be used
+     * @param openDialog - the boolean condition used to check if template should be opened
      */
-    openEditClosedEventDialog(
-        content: PolymorpheusContent<TuiDialogContext>
+    openEditDialog(
+        content: PolymorpheusContent<TuiDialogContext>,
+        openDialog: boolean
     ): void {
-
-        this.dialogService.open(content, {
-            closeable: false,
-            label: 'Edit Finished Event?'
-        }).subscribe()
+        if(openDialog) {
+            this.dialogService.open(content, {
+                closeable: false,
+                label: 'Edit Finished Event?'
+            }).subscribe()
+        } else{
+            this.router.navigate(['/course', this.event.course, 'assignments-exams', this.event.id, 'edit']).then()
+        }
     }
 }


### PR DESCRIPTION
## Description

Describe your changes in detail
Added a dialog for editing an event after it's closed but not before it's open and for editing questions inside the closed event. If the condition is not met, routes to the normal edit page instead of pulling up dialog.

## Types of changes

What types of changes does your code introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

Please link the issue here.
https://github.com/COSC447-Directed-Studies/canvas-gamification-ui/issues/62

## Tests

Please describe in detail what tests you added or changed.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/79422004/221704551-cf59721d-c712-4966-988c-58007090ab24.png)
goes to
![image](https://user-images.githubusercontent.com/79422004/221705046-01081335-5981-48d9-8a0c-7c10ad13ef7a.png)

![image](https://user-images.githubusercontent.com/79422004/221705152-02c9bd1e-b019-4c74-8892-a5b4e4ea2e89.png)
goes to
![image](https://user-images.githubusercontent.com/79422004/221705235-afd2515f-f214-4f76-9cfc-83dbeb2ed5b0.png)

![image](https://user-images.githubusercontent.com/79422004/221705326-8a72a831-cabf-49d3-83ab-5abeee22fe3e.png)
goes to
![image](https://user-images.githubusercontent.com/79422004/221705409-5c683348-5495-4764-ae51-92df109bd21b.png)


In closed event
![image](https://user-images.githubusercontent.com/79422004/221705560-3cb53bee-1a99-4e3b-9921-55b4c2a4aebd.png)
goes to 
![image](https://user-images.githubusercontent.com/79422004/221705661-cd6b3f3e-39e9-4f37-bba5-ddf4db48cd37.png)
goes to
![image](https://user-images.githubusercontent.com/79422004/221705737-b814f41f-9a3b-4637-af1c-07e14403e30a.png)

coming soon:
![image](https://user-images.githubusercontent.com/79422004/221705885-421eed28-26f3-4375-94da-3a7a40a011b8.png)
goes to
![image](https://user-images.githubusercontent.com/79422004/221705955-29bc408e-7011-4713-a2a3-4dd2c0966f20.png)

![image](https://user-images.githubusercontent.com/79422004/221706333-ce83ee6e-bf4c-45ef-ad46-427327f71393.png)
goes to
![image](https://user-images.githubusercontent.com/79422004/221706429-bfd7666e-649e-4a8e-960d-59f41dad3839.png)
