### PR TITLE
Separate list of assignments/exams into 3 accordions like the challenges

### DIFF
--- a/src/app/course/event/course-events-snippet/course-events-snippet.component.html
+++ b/src/app/course/event/course-events-snippet/course-events-snippet.component.html
@@ -100,6 +100,33 @@
         </div>
         <tui-accordion [closeOthers]="false">
             <tui-accordion-item class="title" open="true" [disableHover]="true">
+                Current Assessments
+                <ng-template tuiAccordionItemContent>
+                    <div
+                        *ngFor="let event of getCurrentEvents()"
+                        class="event"
+                    >
+                        <app-event-row
+                            [event]="event"
+                            (reload)="init()"
+                        >
+                        </app-event-row>
+                    </div>
+                    <div *ngIf="getCurrentEvents().length === 0">
+                        <div class="flex justify-center items-center w-full h-32">
+                            <tui-marker-icon
+                                class="tui-space_right-4"
+                                size="s"
+                                src="tuiIconAlertCircleLarge"
+                            ></tui-marker-icon>
+                            <h2 class="tui-text_body-xl">
+                                Looks like there are no current assessments
+                            </h2>
+                        </div>
+                    </div>
+                </ng-template>
+            </tui-accordion-item>
+            <tui-accordion-item class="title" open="true" [disableHover]="true">
                 Upcoming Assessments
                 <ng-template tuiAccordionItemContent>
                     <div

--- a/src/app/course/event/course-events-snippet/course-events-snippet.component.ts
+++ b/src/app/course/event/course-events-snippet/course-events-snippet.component.ts
@@ -77,8 +77,13 @@ export class CourseEventsSnippetComponent implements OnInit {
         }
     }
 
+
+    getCurrentEvents(): CourseEvent[] {
+        return this.getEvents().filter(event => event.is_open)
+    }
+
     getUpcomingEvents(): CourseEvent[] {
-        return this.getEvents().filter(event => event.is_open || event.is_not_available_yet)
+        return this.getEvents().filter(event => event.is_not_available_yet)
     }
 
     getPastEvents(): CourseEvent[] {


### PR DESCRIPTION
## Description

I made a new accordion item for current assessments and changed the logic for upcoming assessments so that current and upcoming assessments are now separate.

## Types of changes

What types of changes does your code introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

#76

## Tests

No tests were added or changed.

## Screenshots (if appropriate):
![Screen Shot 2023-03-07 at 6 41 08 PM](https://user-images.githubusercontent.com/77898527/223605958-4a8876b0-5236-4fe7-b6fe-a2c8be12a57c.png)
