### PR TITLE
fix assessment sidebar spacing

### DIFF
--- a/src/app/course/event/event-question-view/event-question-view.component.html
+++ b/src/app/course/event/event-question-view/event-question-view.component.html
@@ -5,7 +5,7 @@
         sidebarId="eventQuestionSidebar"
         spacing="start"
     >
-        <div class="flex flex-col gap-6">
+        <div class="flex flex-col gap-6 mr-8">
             <a
                 *ngIf="event?.type==='ASSIGNMENT' || 'EXAM'"
                 [routerLink]="['/course', event?.course, 'assignments-exams', eventId]"


### PR DESCRIPTION
## Description

Describe your changes in detail
added a margin to fix sidebar button placement in assessments/challenges

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

Please link the issue here.
https://github.com/COSC447-Directed-Studies/canvas-gamification-ui/issues/115

## Tests

Please describe in detail what tests you added or changed.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/79422004/232256228-66641a37-71ff-43c3-acc0-b2fb0c7077a4.png)
