### PR TITLE
keep_add_new_questions_from_popping_up_during_edit

### DIFF
--- a/src/app/course/_forms/course-event.form.ts
+++ b/src/app/course/_forms/course-event.form.ts
@@ -47,7 +47,7 @@ export class CourseEventForm {
             startTimePicker: new FormControl(TuiTime.currentLocal(), [Validators.required]),
             endTimePicker: new FormControl(TuiTime.currentLocal(), [Validators.required]),
             questionSets: new FormArray(
-                [CourseEventForm.createQuestionSetForm()]
+                []
             )
         }, {validator: CourseEventForm.dateValidator} as AbstractControlOptions)
     }

--- a/src/app/course/_forms/course-event.form.ts
+++ b/src/app/course/_forms/course-event.form.ts
@@ -80,7 +80,7 @@ export class CourseEventForm {
                 [Validators.required]
             ),
             questionSets: new FormArray(
-                [CourseEventForm.createQuestionSetForm()]
+                []
             )
         }, {validator: CourseEventForm.dateValidator} as AbstractControlOptions)
     }

--- a/src/app/course/event/course-event-create/course-event-create-edit.component.ts
+++ b/src/app/course/event/course-event-create/course-event-create-edit.component.ts
@@ -49,6 +49,8 @@ export class CourseEventCreateEditComponent implements OnInit {
             this.courseEventService.getCourseEvent(this.eventId).subscribe(event => {
                 this.formData = CourseEventForm.createFormWithData(event)
             })
+        } else{
+            this.addChallengeQuestionSet()
         }
         this.categoryService.getCategories().subscribe(
             categories => this.categories = categories


### PR DESCRIPTION
## Description

Describe your changes in detail
removed automatic addition of add questions form in the form for both created and edit event. In initialization of the page, added an else to if statement that would re-add the add questions form to the create page. This was done because the create form is initialized first and if it still had the add questions form it would flash up for a second before vanishing, and loading the create form after the if statement for the edit form left the edit form looking weird for a bit as it waited for everything to finish loading in.

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

Please link the issue here.
https://github.com/COSC447-Directed-Studies/canvas-gamification-ui/issues/119

## Tests

Please describe in detail what tests you added or changed.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/79422004/232259027-e4e864c6-0169-4378-9ad6-a52ba8b45b06.png)
![image](https://user-images.githubusercontent.com/79422004/232259034-5236017d-8de7-404b-8219-25c1a4b86318.png)
