### PR TITLE
fix mcq answer display

### DIFF
--- a/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
+++ b/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
@@ -23,7 +23,10 @@
                                 Received: {{ submission.tokens_received.toFixed(2)}}
                                 / {{submission.token_value.toFixed(2) }}</p>
                             <p class="tui-island__paragraph">Answer:</p>
-                            <ng-container *ngIf="submission.show_answer else noAnswerShown">
+                            <ng-container *ngIf="submission.show_answer &&
+                            submission.safeAnswer.toString().length < 500 &&
+                            submission.safeAnswer.toString().indexOf('image') === -1
+                            else noAnswerShown">
                                 <div *ngFor="let safeAnswer of submission.safeAnswer"
                                      [innerHTML]="safeAnswer"></div>
                             </ng-container>
@@ -43,7 +46,50 @@
                                     See Details
                                 </button>
                             </div>
+                            <div class="tui-form__buttons tui-space_top-4"
+                                 *ngIf="submission.safeAnswer.toString().length >= 500
+                                    || submission.safeAnswer.toString().indexOf('image') !== -1">
+                                <button
+                                    (click)="openMCQSubmissionDialog(mcqAnswers)"
+                                    class="tui-form__button"
+                                    size="m"
+                                    tuiButton
+                                >
+                                    See Details
+                                </button>
+                            </div>
                         </div>
+                        <ng-template #mcqAnswers let-observer>
+                            <p class="tui-island__paragraph">
+                                Grade Given:
+                                {{ submission?.grade || 'No Grade' }}
+                            </p>
+                            <p class="tui-island__paragraph">
+                                Score:
+                                {{ submission?.get_formatted_test_results }}
+                            </p>
+                            <p class="tui-island__paragraph">
+                                Tokens Received:
+                                {{ submission?.formatted_tokens_received }}
+                            </p>
+                            <p class="tui-island__paragraph">
+                                Time Submitted:
+                                {{ (submission?.submission_time | date: 'medium') || 'No Time'}}
+                            </p>
+                            <div *ngFor="let safeAnswer of submission.safeAnswer"
+                                 [innerHTML]="safeAnswer"></div>
+                            <div class="tui-form__buttons">
+                                <button
+                                    (click)="observer.complete()"
+                                    appearance="primary"
+                                    class="tui-form__button"
+                                    size="m"
+                                    tuiButton
+                                >
+                                    Close
+                                </button>
+                            </div>
+                        </ng-template>
                         <ng-template #examContent>
                             <p class="tui-island__paragraph">
                                 Exam is in progress. You can see the submission results once the

--- a/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
+++ b/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
@@ -24,7 +24,7 @@
                                 / {{submission.token_value.toFixed(2) }}</p>
                             <p class="tui-island__paragraph">Answer:</p>
                             <ng-container *ngIf="submission.show_answer else noAnswerShown">
-                                <div *ngFor="let safeAnswer of submission.answer_display"
+                                <div *ngFor="let safeAnswer of submission.safeAnswer"
                                      [innerHTML]="safeAnswer"></div>
                             </ng-container>
                             <ng-template #noAnswerShown>

--- a/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
+++ b/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
@@ -24,7 +24,7 @@
                                 / {{submission.token_value.toFixed(2) }}</p>
                             <p class="tui-island__paragraph">Answer:</p>
                             <ng-container *ngIf="submission.show_answer else noAnswerShown">
-                                <div *ngFor="let safeAnswer of submission.safeAnswer"
+                                <div *ngFor="let safeAnswer of submission.answer_display"
                                      [innerHTML]="safeAnswer"></div>
                             </ng-container>
                             <ng-template #noAnswerShown>

--- a/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
+++ b/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
@@ -50,7 +50,7 @@
                                  *ngIf="submission.safeAnswer.toString().length >= 500
                                     || submission.safeAnswer.toString().indexOf('image') !== -1">
                                 <button
-                                    (click)="openMCQSubmissionDialog(mcqAnswers)"
+                                    (click)="openMCQSubmissionDialog(mcqAnswers, index + 1)"
                                     class="tui-form__button"
                                     size="m"
                                     tuiButton
@@ -60,22 +60,16 @@
                             </div>
                         </div>
                         <ng-template #mcqAnswers let-observer>
-                            <p class="tui-island__paragraph">
-                                Grade Given:
-                                {{ submission?.grade || 'No Grade' }}
-                            </p>
-                            <p class="tui-island__paragraph">
-                                Score:
-                                {{ submission?.get_formatted_test_results }}
-                            </p>
-                            <p class="tui-island__paragraph">
-                                Tokens Received:
-                                {{ submission?.formatted_tokens_received }}
-                            </p>
+                            <p class="tui-island__paragraph">Grade
+                                Given: {{ submission.grade.toFixed(2) }}</p>
+                            <p class="tui-island__paragraph">Tokens
+                                Received: {{ submission.tokens_received.toFixed(2)}}
+                                / {{submission.token_value.toFixed(2) }}</p>
                             <p class="tui-island__paragraph">
                                 Time Submitted:
                                 {{ (submission?.submission_time | date: 'medium') || 'No Time'}}
                             </p>
+                            <p class="tui-island__paragraph">Answer:</p>
                             <div *ngFor="let safeAnswer of submission.safeAnswer"
                                  [innerHTML]="safeAnswer"></div>
                             <div class="tui-form__buttons">

--- a/src/app/problems/problem-view/submission-snippet/submission-snippet.component.ts
+++ b/src/app/problems/problem-view/submission-snippet/submission-snippet.component.ts
@@ -59,7 +59,9 @@ export class SubmissionSnippetComponent implements OnChanges, OnInit {
         )
             .pipe(map(submissions => submissions.map(submission => ({
                 ...submission,
-                safeAnswer: [this.sanitizer.bypassSecurityTrustHtml(submission.answer)]
+                safeAnswer: [this.sanitizer.bypassSecurityTrustHtml(
+                    submission.answer_display.toString()
+                )]
             }))))
             .subscribe(submissions => {
                 this.previousSubmissions = submissions

--- a/src/app/problems/problem-view/submission-snippet/submission-snippet.component.ts
+++ b/src/app/problems/problem-view/submission-snippet/submission-snippet.component.ts
@@ -83,11 +83,10 @@ export class SubmissionSnippetComponent implements OnChanges, OnInit {
         ).subscribe()
     }
 
-    //dont open this, open a html template set up in the html a la assignment is closed
-    openMCQSubmissionDialog(content: PolymorpheusContent<TuiDialogContext>): void {
+    openMCQSubmissionDialog(content: PolymorpheusContent<TuiDialogContext>, index: number): void {
         this.dialogService.open(content, {
             closeable: false,
-            label: 'Edit finished assessment?'
+            label: `Submission ${index}`
         }).subscribe()
     }
 }

--- a/src/app/problems/problem-view/submission-snippet/submission-snippet.component.ts
+++ b/src/app/problems/problem-view/submission-snippet/submission-snippet.component.ts
@@ -10,8 +10,8 @@ import {
 } from '@angular/core'
 import {QuestionSubmission} from '@app/_models/question_submission'
 import {DomSanitizer} from "@angular/platform-browser"
-import {TuiDialogService} from '@taiga-ui/core'
-import {PolymorpheusComponent} from '@tinkoff/ng-polymorpheus'
+import {TuiDialogContext, TuiDialogService} from '@taiga-ui/core'
+import {PolymorpheusComponent, PolymorpheusContent} from '@tinkoff/ng-polymorpheus'
 import {SubmissionViewComponent} from '@app/problems/submission-view/submission-view.component'
 import {SubmissionService} from "@app/problems/_services/submission.service"
 import {map} from "rxjs/operators"
@@ -81,5 +81,13 @@ export class SubmissionSnippetComponent implements OnChanges, OnInit {
                 label: `Submission ${index}`
             }
         ).subscribe()
+    }
+
+    //dont open this, open a html template set up in the html a la assignment is closed
+    openMCQSubmissionDialog(content: PolymorpheusContent<TuiDialogContext>): void {
+        this.dialogService.open(content, {
+            closeable: false,
+            label: 'Edit finished assessment?'
+        }).subscribe()
     }
 }


### PR DESCRIPTION
## Description

Describe your changes in detail
Altered the safeAnswer definition to show the answer text not the a b c d etc. value, created a popup for if the answer is an image or goes over a certain size limit to display there instead of in the sidebar/

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

Please link the issue here.
https://github.com/COSC447-Directed-Studies/canvas-gamification-ui/issues/121

## Tests

Please describe in detail what tests you added or changed.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/79422004/234169819-0f48f8fb-783d-4786-9c24-eeb8d86c93ac.png)
![image](https://user-images.githubusercontent.com/79422004/234169845-173c993b-e9c0-4fb3-80fa-55580531f592.png)
![image](https://user-images.githubusercontent.com/79422004/234169884-e6daa08e-6cc0-46e6-b528-c8bed7905984.png)
![image](https://user-images.githubusercontent.com/79422004/234169912-b9223c69-ceee-4056-9648-0626e55139a7.png)
![image](https://user-images.githubusercontent.com/79422004/234169942-7e035341-b374-4b88-b75a-772580fb6478.png)
![image](https://user-images.githubusercontent.com/79422004/234169992-390fa41b-90a6-404b-a8eb-d29353dcb6ef.png)
